### PR TITLE
fixed Invalid schema for guessinggame example #39

### DIFF
--- a/examples/apps/number_guessing_game/index.js
+++ b/examples/apps/number_guessing_game/index.js
@@ -13,7 +13,7 @@ app.launch(function(req,res) {
 	var prompt = "Guess a number between 1 and 100!";
 	res.say(prompt).reprompt(prompt).shouldEndSession(false);
 });
-app.intent('guess',{
+app.intent('GuessIntent',{
 		"slots":{"guess":"NUMBER"}
 		,"utterances":["{1-100|guess}"]
 	},


### PR DESCRIPTION
Amazon requires intents and slots to have different names. Changing the intent to GameIntent fixes this problem and is consistent with the naming of the other example.