### PR TITLE
Mocha Testing changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,42 @@
 language: node_js
 
-node_js:
-  - 6.1
-
 sudo: false
+
+node_js:
+- '0.10'
+- '0.12'
+- '1'
+- '2'
+- '3'
+- '4'
+- '5'
+- '6'
+- '7'
+
+matrix:
+  include:
+  - node_js: '0.10'
+    env: BROWSER_NAME=chrome BROWSER_VERSION=latest
+  - node_js: '0.10'
+    env: BROWSER_NAME=chrome BROWSER_VERSION=29
+  - node_js: '0.10'
+    env: BROWSER_NAME=firefox BROWSER_VERSION=latest
+  - node_js: '0.10'
+    env: BROWSER_NAME=opera BROWSER_VERSION=latest
+  - node_js: '0.10'
+    env: BROWSER_NAME=safari BROWSER_VERSION=latest
+  - node_js: '0.10'
+    env: BROWSER_NAME=safari BROWSER_VERSION=7
+  - node_js: '0.10'
+    env: BROWSER_NAME=safari BROWSER_VERSION=6
+  - node_js: '0.10'
+    env: BROWSER_NAME=safari BROWSER_VERSION=5
+  - node_js: '0.10'
+    env: BROWSER_NAME=ie BROWSER_VERSION=11
+  - node_js: '0.10'
+    env: BROWSER_NAME=ie BROWSER_VERSION=10
+  - node_js: '0.10'
+    env: BROWSER_NAME=ie BROWSER_VERSION=9
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 sudo: false
 
 node_js:
-- '0.10'
 - '0.12'
 - '1'
 - '2'
@@ -12,31 +11,6 @@ node_js:
 - '5'
 - '6'
 - '7'
-
-matrix:
-  include:
-  - node_js: '0.10'
-    env: BROWSER_NAME=chrome BROWSER_VERSION=latest
-  - node_js: '0.10'
-    env: BROWSER_NAME=chrome BROWSER_VERSION=29
-  - node_js: '0.10'
-    env: BROWSER_NAME=firefox BROWSER_VERSION=latest
-  - node_js: '0.10'
-    env: BROWSER_NAME=opera BROWSER_VERSION=latest
-  - node_js: '0.10'
-    env: BROWSER_NAME=safari BROWSER_VERSION=latest
-  - node_js: '0.10'
-    env: BROWSER_NAME=safari BROWSER_VERSION=7
-  - node_js: '0.10'
-    env: BROWSER_NAME=safari BROWSER_VERSION=6
-  - node_js: '0.10'
-    env: BROWSER_NAME=safari BROWSER_VERSION=5
-  - node_js: '0.10'
-    env: BROWSER_NAME=ie BROWSER_VERSION=11
-  - node_js: '0.10'
-    env: BROWSER_NAME=ie BROWSER_VERSION=10
-  - node_js: '0.10'
-    env: BROWSER_NAME=ie BROWSER_VERSION=9
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ language: node_js
 sudo: false
 
 node_js:
-- '0.12'
-- '1'
-- '2'
-- '3'
-- '4'
-- '5'
 - '6'
 - '7'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Changelog
 
 ### 2.3.2 (Next)
-* [#48](https://github.com/alexa-js/alexa-app-server/pull/46): Removed deprecated dependency 'supertest-as-promised' - [@tejashah88](https://github.com/tejashah88).
-* [#48](https://github.com/alexa-js/alexa-app-server/pull/46): Added tests to verify that server does not always bind to both HTTP and HTTPS ports [#46](https://github.com/alexa-js/alexa-app-server/issues/46) - [@tejashah88](https://github.com/tejashah88).
+* [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Added more node versions to run mocha tests - [@tejashah88](https://github.com/tejashah88).
+* [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Removed deprecated dependency 'supertest-as-promised' - [@tejashah88](https://github.com/tejashah88).
+* [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Added tests to verify that server does not always bind to both HTTP and HTTPS ports [#46](https://github.com/alexa-js/alexa-app-server/issues/46) - [@tejashah88](https://github.com/tejashah88).
 * [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added support for ca chain certificates [#17](https://github.com/alexa-js/alexa-app-server/issues/17) - [@tejashah88](https://github.com/tejashah88).
 * [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added option to specify passphrase for unlocking specified SSL files - [@tejashah88](https://github.com/tejashah88).
 * [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added npm command to examine test coverage locally - [@tejashah88](https://github.com/tejashah88).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Added more node versions to run mocha tests on Travis-CI - [@tejashah88](https://github.com/tejashah88).
 * [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Removed deprecated dependency 'supertest-as-promised' - [@tejashah88](https://github.com/tejashah88).
 * [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Added tests to verify that server does not always bind to both HTTP and HTTPS ports [#46](https://github.com/alexa-js/alexa-app-server/issues/46) - [@tejashah88](https://github.com/tejashah88).
+* [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Added more node versions to run mocha tests on Travis-CI - [@tejashah88](https://github.com/tejashah88).
 * [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added support for ca chain certificates [#17](https://github.com/alexa-js/alexa-app-server/issues/17) - [@tejashah88](https://github.com/tejashah88).
 * [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added option to specify passphrase for unlocking specified SSL files - [@tejashah88](https://github.com/tejashah88).
 * [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added npm command to examine test coverage locally - [@tejashah88](https://github.com/tejashah88).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog
 
 ### 2.3.2 (Next)
-* [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Added more node versions to run mocha tests - [@tejashah88](https://github.com/tejashah88).
+* [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Added more node versions to run mocha tests on Travis-CI - [@tejashah88](https://github.com/tejashah88).
 * [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Removed deprecated dependency 'supertest-as-promised' - [@tejashah88](https://github.com/tejashah88).
 * [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Added tests to verify that server does not always bind to both HTTP and HTTPS ports [#46](https://github.com/alexa-js/alexa-app-server/issues/46) - [@tejashah88](https://github.com/tejashah88).
 * [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added support for ca chain certificates [#17](https://github.com/alexa-js/alexa-app-server/issues/17) - [@tejashah88](https://github.com/tejashah88).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Changelog
 
 ### 2.3.2 (Next)
-* [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added support for ca chain certificates [#17](https://github.com/alexa-js/alexa-app-server/pull/17) - [@tejashah88](https://github.com/tejashah88).
+* [#48](https://github.com/alexa-js/alexa-app-server/pull/46): Removed deprecated dependency 'supertest-as-promised' - [@tejashah88](https://github.com/tejashah88).
+* [#48](https://github.com/alexa-js/alexa-app-server/pull/46): Added tests to verify that server does not always bind to both HTTP and HTTPS ports [#46](https://github.com/alexa-js/alexa-app-server/issues/46) - [@tejashah88](https://github.com/tejashah88).
+* [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added support for ca chain certificates [#17](https://github.com/alexa-js/alexa-app-server/issues/17) - [@tejashah88](https://github.com/tejashah88).
 * [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added option to specify passphrase for unlocking specified SSL files - [@tejashah88](https://github.com/tejashah88).
 * [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added npm command to examine test coverage locally - [@tejashah88](https://github.com/tejashah88).
 * [#22](https://github.com/alexa-js/alexa-app-server/pull/22): Adding Context object to request templates + Refactored debugger files - [@pwbrown](https://github.com/pwbrown).

--- a/package.json
+++ b/package.json
@@ -32,9 +32,8 @@
     "mocha": "^3.2.0",
     "chai": "^3.5.0",
     "supertest": "^3.0.0",
-    "supertest-as-promised": "^4.0.2",
     "istanbul": "0.4.5",
     "coveralls": "^2.11.15",
-    "danger": "0.10.0"
+    "danger": "0.11.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "supertest": "^3.0.0",
     "istanbul": "0.4.5",
     "coveralls": "^2.11.15",
-    "danger": "0.8.0"
+    "danger": "0.11.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "supertest": "^3.0.0",
     "istanbul": "0.4.5",
     "coveralls": "^2.11.15",
-    "danger": "0.11.2"
+    "danger": "0.8.0"
   }
 }

--- a/test/test-examples-server-app-loading-fail-checks.js
+++ b/test/test-examples-server-app-loading-fail-checks.js
@@ -3,7 +3,7 @@
 var chai = require("chai");
 var expect = chai.expect;
 chai.config.includeStack = true;
-var request = require("supertest-as-promised");
+var request = require("supertest");
 var alexaAppServer = require("../index");
 
 describe("Alexa App Server with invalid examples", function() {

--- a/test/test-examples-server-custom-bindings.js
+++ b/test/test-examples-server-custom-bindings.js
@@ -3,7 +3,7 @@
 var chai = require("chai");
 var expect = chai.expect;
 chai.config.includeStack = true;
-var request = require("supertest-as-promised");
+var request = require("supertest");
 var alexaAppServer = require("../index");
 
 describe("Alexa App Server with Examples & Custom Server Bindings", function() {

--- a/test/test-examples-server-debug-verify.js
+++ b/test/test-examples-server-debug-verify.js
@@ -3,7 +3,7 @@
 var chai = require("chai");
 var expect = chai.expect;
 chai.config.includeStack = true;
-var request = require("supertest-as-promised");
+var request = require("supertest");
 var alexaAppServer = require("../index");
 
 describe("Alexa App Server with Examples & App loading fail checking", function() {

--- a/test/test-examples-server-https-fail-checks.js
+++ b/test/test-examples-server-https-fail-checks.js
@@ -3,7 +3,7 @@
 var chai = require("chai");
 var expect = chai.expect;
 chai.config.includeStack = true;
-var request = require("supertest-as-promised");
+var request = require("supertest");
 var alexaAppServer = require("../index");
 
 describe("Alexa App Server with Examples & HTTPS fail checking", function() {
@@ -28,45 +28,74 @@ describe("Alexa App Server with Examples & HTTPS fail checking", function() {
   });
 
   it("fails to mount due to invalid private key and certificate", function() {
-      testServer = alexaAppServer.start({
-        port: 3000,
-        server_root: 'invalid_examples',
-        httpsEnabled: true,
-        httpsPort: 6000,
-        privateKey: 'invalid-private-key.pem',
-        certificate: 'invalid-cert.cer'
-      });
+    testServer = alexaAppServer.start({
+      port: 3000,
+      server_root: 'invalid_examples',
+      httpsEnabled: true,
+      httpsPort: 6000,
+      privateKey: 'invalid-private-key.pem',
+      certificate: 'invalid-cert.cer'
+    });
 
-      return request(testServer.express)
-        .get('/')
-        .expect(200).then(function(response) {
-          expect(response.text).to.contain("alexa-app-server is running");
-        }
-      );
+    return request(testServer.express)
+      .get('/')
+      .expect(200).then(function(response) {
+        expect(response.text).to.contain("alexa-app-server is running");
+      });
   });
 
   it("fails to mount due to invalid CA chain file", function() {
-      testServer = alexaAppServer.start({
-        port: 3000,
-        server_root: 'invalid_examples',
-        httpsEnabled: true,
-        httpsPort: 6000,
-        privateKey: 'private-key.pem',
-        certificate: 'cert.cer',
-        chain: 'invalid-cert.ca_bundle'
+    testServer = alexaAppServer.start({
+      port: 3000,
+      server_root: 'invalid_examples',
+      httpsEnabled: true,
+      httpsPort: 6000,
+      privateKey: 'private-key.pem',
+      certificate: 'cert.cer',
+      chain: 'invalid-cert.ca_bundle'
+    });
+
+    return request(testServer.express)
+      .get('/')
+      .expect(200).then(function(response) {
+        expect(response.text).to.contain("alexa-app-server is running");
+      });
+  });
+
+  it("fails to mount due to no passphrase given", function() {
+    testServer = alexaAppServer.start({
+      port: 3000,
+      server_root: 'invalid_examples',
+      httpsEnabled: true,
+      httpsPort: 6000,
+      privateKey: 'private-key.pem',
+      certificate: 'cert.cer',
+      chain: 'cert.ca_bundle'
+    });
+
+    return request(testServer.express)
+      .get('/')
+      .expect(200).then(function(response) {
+        expect(response.text).to.contain("alexa-app-server is running");
       });
   });
 
   it("fails to mount due to invalid passphrase", function() {
-      testServer = alexaAppServer.start({
-        port: 3000,
-        server_root: 'invalid_examples',
-        httpsEnabled: true,
-        httpsPort: 6000,
-        privateKey: 'private-key.pem',
-        certificate: 'cert.cer',
-        chain: 'cert.ca_bundle',
-        passphrase: "test321"
+    testServer = alexaAppServer.start({
+      port: 3000,
+      server_root: 'invalid_examples',
+      httpsEnabled: true,
+      httpsPort: 6000,
+      privateKey: 'private-key.pem',
+      certificate: 'cert.cer',
+      chain: 'cert.ca_bundle',
+      passphrase: "test321"
+    });
+
+    return request(testServer.express)
+      .get('/')
+      .expect(200).then(function(response) {
+        expect(response.text).to.contain("alexa-app-server is running");
       });
   });
 
@@ -77,7 +106,8 @@ describe("Alexa App Server with Examples & HTTPS fail checking", function() {
       httpsEnabled: true,
       httpsPort: -1,
       privateKey: 'private-key.pem',
-      certificate: 'cert.cer'
+      certificate: 'cert.cer',
+      passphrase: "test123"
     });
 
     return request(testServer.express)

--- a/test/test-examples-server-https-support-extended.js
+++ b/test/test-examples-server-https-support-extended.js
@@ -1,0 +1,187 @@
+/*jshint expr: true*/
+"use strict";
+var chai = require("chai");
+var expect = chai.expect;
+chai.config.includeStack = true;
+var request = require("supertest");
+var alexaAppServer = require("../index");
+var fs = require("fs");
+
+describe("Alexa App Server with Examples & more HTTPS support", function() {
+  var testServer;
+  var sampleLaunchReq;
+
+  function isPortTaken(config, fn) {
+    var port = config.port;
+    var address = config.host;
+
+    var success_ix = 0;
+    var net = require('net');
+
+    var test_ipv4 = net.createServer()
+      .once('error', function(err) {
+        if (err.code != 'EADDRINUSE')
+          return fn(err)
+        fn(null, true);
+      })
+      .once('listening', function() {
+        test_ipv4.once('close', function() {
+          success_ix++;
+          if (success_ix == 2)
+            fn(null, false);
+        })
+        .close()
+      })
+      .listen(port, (address !== undefined) ? address : '0.0.0.0');
+
+    var test_ipv6 = net.createServer()
+      .once('error', function (err) {
+        if (err.code != 'EADDRINUSE')
+          return fn(err)
+        fn(null, true)
+      })
+      .once('listening', function() {
+        test_ipv6.once('close', function() {
+          success_ix++;
+          if (success_ix == 2)
+            fn(null, false)
+        })
+        .close()
+      })
+      .listen(port, (address !== undefined) ? '::1' : '::');
+  };
+
+  before(function() {
+    sampleLaunchReq = JSON.parse(fs.readFileSync("test/sample-launch-req.json", 'utf8'));
+  });
+
+  afterEach(function() {
+    testServer.stop();
+  });
+
+  describe("No specific address given", function() {
+    it("should only have the HTTP server instance running", function(done) {
+      testServer = alexaAppServer.start({
+        port: 3000,
+        server_root: 'examples'
+      });
+
+      request(testServer.express)
+        .get('/alexa/helloworld')
+        .expect(200).then(function(response) {
+          // First, check that the actual server instances exist or not
+          expect(testServer.httpInstance).to.exist;
+          expect(testServer.httpsInstance).to.not.exist;
+
+          // Then, check if the ports are actually bound or not
+          isPortTaken({ port: 3000 }, function(err, result) {
+            expect(err).to.not.exist;
+            expect(result).to.be.true;
+
+            isPortTaken({ port: 6000 }, function(err, result) {
+              expect(err).to.not.exist;
+              expect(result).to.be.false;
+              done();
+            });
+          });
+        });
+    });
+
+    it("should have the HTTP and HTTPS server instances running", function(done) {
+      testServer = alexaAppServer.start({
+        port: 3000,
+        server_root: 'examples',
+        httpsEnabled: true,
+        httpsPort: 6000,
+        privateKey: 'private-key.pem',
+        certificate: 'cert.cer',
+        chain: 'cert.ca_bundle',
+        passphrase: "test123"
+      });
+
+      request(testServer.express)
+        .get('/alexa/helloworld')
+        .expect(200).then(function(response) {
+          // First, check that the actual server instances exist or not
+          expect(testServer.httpInstance).to.exist;
+          expect(testServer.httpsInstance).to.exist;
+
+          // Then, check if the ports are actually bound or not
+          isPortTaken({ port: 3000 }, function(err, result) {
+            expect(err).to.not.exist;
+            expect(result).to.be.true;
+
+            isPortTaken({ port: 3000 }, function(err, result) {
+              expect(err).to.not.exist;
+              expect(result).to.be.true;
+              done();
+            });
+          });
+        });
+    });
+  });
+
+  describe("Specific address given (127.0.0.1)", function() {
+    it("should only have the HTTP server instance running", function(done) {
+      testServer = alexaAppServer.start({
+        port: 3000,
+        host: '127.0.0.1',
+        server_root: 'examples'
+      });
+
+      request(testServer.express)
+        .get('/alexa/helloworld')
+        .expect(200).then(function(response) {
+          // First, check that the actual server instances exist or not
+          expect(testServer.httpInstance).to.exist;
+          expect(testServer.httpsInstance).to.not.exist;
+
+          // Then, check if the ports are actually bound or not
+          isPortTaken({ port: 3000, host: '127.0.0.1' }, function(err, result) {
+            expect(err).to.not.exist;
+            expect(result).to.be.true;
+
+            isPortTaken({ port: 6000, host: '127.0.0.1' }, function(err, result) {
+              expect(err).to.not.exist;
+              expect(result).to.be.false;
+              done();
+            });
+          });
+        });
+    });
+
+    it("should have the HTTP and HTTPS server instances running", function(done) {
+      testServer = alexaAppServer.start({
+        port: 3000,
+        host: '127.0.0.1',
+        server_root: 'examples',
+        httpsEnabled: true,
+        httpsPort: 6000,
+        privateKey: 'private-key.pem',
+        certificate: 'cert.cer',
+        chain: 'cert.ca_bundle',
+        passphrase: "test123"
+      });
+
+      request(testServer.express)
+        .get('/alexa/helloworld')
+        .expect(200).then(function(response) {
+          // First, check that the actual server instances exist or not
+          expect(testServer.httpInstance).to.exist;
+          expect(testServer.httpsInstance).to.exist;
+
+          // Then, check if the ports are actually bound or not
+          isPortTaken({ port: 3000, host: '127.0.0.1' }, function(err, result) {
+            expect(err).to.not.exist;
+            expect(result).to.be.true;
+
+            isPortTaken({ port: 3000, host: '127.0.0.1' }, function(err, result) {
+              expect(err).to.not.exist;
+              expect(result).to.be.true;
+              done();
+            });
+          });
+        });
+    });
+  });
+});

--- a/test/test-examples-server-https-support-extended.js
+++ b/test/test-examples-server-https-support-extended.js
@@ -60,13 +60,13 @@ describe("Alexa App Server with Examples & more HTTPS support", function() {
   });
 
   describe("No specific address given", function() {
-    it("should only have the HTTP server instance running", function(done) {
+    it("should only have the HTTP server instance running", function() {
       testServer = alexaAppServer.start({
         port: 3000,
         server_root: 'examples'
       });
 
-      request(testServer.express)
+      return request(testServer.express)
         .get('/alexa/helloworld')
         .expect(200).then(function(response) {
           // First, check that the actual server instances exist or not
@@ -81,13 +81,12 @@ describe("Alexa App Server with Examples & more HTTPS support", function() {
             isPortTaken({ port: 6000 }, function(err, result) {
               expect(err).to.not.exist;
               expect(result).to.be.false;
-              done();
             });
           });
         });
     });
 
-    it("should have the HTTP and HTTPS server instances running", function(done) {
+    it("should have the HTTP and HTTPS server instances running", function() {
       testServer = alexaAppServer.start({
         port: 3000,
         server_root: 'examples',
@@ -99,7 +98,7 @@ describe("Alexa App Server with Examples & more HTTPS support", function() {
         passphrase: "test123"
       });
 
-      request(testServer.express)
+      return request(testServer.express)
         .get('/alexa/helloworld')
         .expect(200).then(function(response) {
           // First, check that the actual server instances exist or not
@@ -114,7 +113,6 @@ describe("Alexa App Server with Examples & more HTTPS support", function() {
             isPortTaken({ port: 3000 }, function(err, result) {
               expect(err).to.not.exist;
               expect(result).to.be.true;
-              done();
             });
           });
         });
@@ -122,14 +120,14 @@ describe("Alexa App Server with Examples & more HTTPS support", function() {
   });
 
   describe("Specific address given (127.0.0.1)", function() {
-    it("should only have the HTTP server instance running", function(done) {
+    it("should only have the HTTP server instance running", function() {
       testServer = alexaAppServer.start({
         port: 3000,
         host: '127.0.0.1',
         server_root: 'examples'
       });
 
-      request(testServer.express)
+      return request(testServer.express)
         .get('/alexa/helloworld')
         .expect(200).then(function(response) {
           // First, check that the actual server instances exist or not
@@ -144,13 +142,12 @@ describe("Alexa App Server with Examples & more HTTPS support", function() {
             isPortTaken({ port: 6000, host: '127.0.0.1' }, function(err, result) {
               expect(err).to.not.exist;
               expect(result).to.be.false;
-              done();
             });
           });
         });
     });
 
-    it("should have the HTTP and HTTPS server instances running", function(done) {
+    it("should have the HTTP and HTTPS server instances running", function() {
       testServer = alexaAppServer.start({
         port: 3000,
         host: '127.0.0.1',
@@ -163,7 +160,7 @@ describe("Alexa App Server with Examples & more HTTPS support", function() {
         passphrase: "test123"
       });
 
-      request(testServer.express)
+      return request(testServer.express)
         .get('/alexa/helloworld')
         .expect(200).then(function(response) {
           // First, check that the actual server instances exist or not
@@ -178,7 +175,6 @@ describe("Alexa App Server with Examples & more HTTPS support", function() {
             isPortTaken({ port: 3000, host: '127.0.0.1' }, function(err, result) {
               expect(err).to.not.exist;
               expect(result).to.be.true;
-              done();
             });
           });
         });

--- a/test/test-examples-server-https-support.js
+++ b/test/test-examples-server-https-support.js
@@ -3,11 +3,13 @@
 var chai = require("chai");
 var expect = chai.expect;
 chai.config.includeStack = true;
-var request = require("supertest-as-promised");
+var request = require("supertest");
 var alexaAppServer = require("../index");
+var fs = require("fs");
 
 describe("Alexa App Server with Examples & HTTPS support", function() {
   var testServer;
+  var sampleLaunchReq;
 
   before(function() {
     testServer = alexaAppServer.start({
@@ -20,27 +22,54 @@ describe("Alexa App Server with Examples & HTTPS support", function() {
       chain: 'cert.ca_bundle',
       passphrase: "test123"
     });
+
+    sampleLaunchReq = JSON.parse(fs.readFileSync("test/sample-launch-req.json", 'utf8'));
   });
 
   after(function() {
     testServer.stop();
   });
 
-  it("mounts hello world app", function() {
-    return request(testServer.express)
-      .get('/alexa/helloworld')
-      .expect(200);
+  describe("GET requests", function() {
+    it("mounts hello world app", function() {
+      return request(testServer.express)
+        .get('/alexa/helloworld')
+        .expect(200);
+    });
+
+    it("mounts number_guessing_game", function() {
+      return request(testServer.express)
+        .get('/alexa/guessinggame')
+        .expect(200);
+    });
+
+    it("404s on an invalid app", function() {
+      return request(testServer.express)
+        .get('/alexa/invalid')
+        .expect(404);
+    });
   });
 
-  it("mounts number_guessing_game", function() {
-    return request(testServer.express)
-      .get('/alexa/guessinggame')
-      .expect(200);
-  });
+  describe("POST requests", function() {
+    it("mounts hello world app", function() {
+      return request(testServer.express)
+        .post('/alexa/helloworld')
+        .send(sampleLaunchReq)
+        .expect(200);
+    });
 
-  it("404s on an invalid app", function() {
-    return request(testServer.express)
-      .get('/alexa/invalid')
-      .expect(404);
+    it("mounts number_guessing_game", function() {
+      return request(testServer.express)
+        .post('/alexa/guessinggame')
+        .send(sampleLaunchReq)
+        .expect(200);
+    });
+
+    it("404s on an invalid app", function() {
+      return request(testServer.express)
+        .post('/alexa/invalid')
+        .send(sampleLaunchReq)
+        .expect(404);
+    });
   });
 });

--- a/test/test-examples-server-pre-post-functions.js
+++ b/test/test-examples-server-pre-post-functions.js
@@ -3,15 +3,13 @@
 var chai = require("chai");
 var expect = chai.expect;
 chai.config.includeStack = true;
-var request = require("supertest-as-promised");
-var fs = require('fs');
+var request = require("supertest");
 var alexaAppServer = require("../index");
+var fs = require("fs");
 
 describe("Alexa App Server with Examples & Pre/Post functions", function() {
-  var testServer;
-  var fired;
-
-  var sampleLaunchReq = JSON.parse(fs.readFileSync("test/sample-launch-req.json", 'utf8'));
+  var testServer, fired;
+  var sampleLaunchReq;
 
   before(function() {
     fired = {};
@@ -31,6 +29,8 @@ describe("Alexa App Server with Examples & Pre/Post functions", function() {
         fired.postRequest = true;
       }
     });
+
+    sampleLaunchReq = JSON.parse(fs.readFileSync("test/sample-launch-req.json", 'utf8'));
   });
 
   after(function() {

--- a/test/test-examples-server-verification.js
+++ b/test/test-examples-server-verification.js
@@ -3,11 +3,13 @@
 var chai = require("chai");
 var expect = chai.expect;
 chai.config.includeStack = true;
-var request = require("supertest-as-promised");
+var request = require("supertest");
 var alexaAppServer = require("../index");
+var fs = require("fs");
 
 describe("Alexa App Server with Examples & Verification", function() {
   var testServer;
+  var sampleLaunchReq;
 
   before(function() {
     testServer = alexaAppServer.start({
@@ -15,27 +17,54 @@ describe("Alexa App Server with Examples & Verification", function() {
       server_root: 'examples',
       verify: true
     });
+
+    sampleLaunchReq = JSON.parse(fs.readFileSync("test/sample-launch-req.json", 'utf8'));
   });
 
   after(function() {
     testServer.stop();
   });
 
-  it("mounts hello world app", function() {
-    return request(testServer.express)
-      .get('/alexa/helloworld')
-      .expect(200);
+  describe("GET requests", function() {
+    it("mounts hello world app", function() {
+      return request(testServer.express)
+        .get('/alexa/helloworld')
+        .expect(200);
+    });
+
+    it("mounts number_guessing_game", function() {
+      return request(testServer.express)
+        .get('/alexa/guessinggame')
+        .expect(200);
+    });
+
+    it("404s on an invalid app", function() {
+      return request(testServer.express)
+        .get('/alexa/invalid')
+        .expect(404);
+    });
   });
 
-  it("mounts number_guessing_game app", function() {
-    return request(testServer.express)
-      .get('/alexa/guessinggame')
-      .expect(200);
-  });
+  describe("POST requests", function() {
+    it("mounts hello world app", function() {
+      return request(testServer.express)
+        .post('/alexa/helloworld')
+        .send(sampleLaunchReq)
+        .expect(200);
+    });
 
-  it("404s on an invalid app", function() {
-    return request(testServer.express)
-      .get('/alexa/invalid')
-      .expect(404);
+    it("mounts number_guessing_game", function() {
+      return request(testServer.express)
+        .post('/alexa/guessinggame')
+        .send(sampleLaunchReq)
+        .expect(200);
+    });
+
+    it("404s on an invalid app", function() {
+      return request(testServer.express)
+        .post('/alexa/invalid')
+        .send(sampleLaunchReq)
+        .expect(404);
+    });
   });
 });

--- a/test/test-examples-server-verification.js
+++ b/test/test-examples-server-verification.js
@@ -25,17 +25,18 @@ describe("Alexa App Server with Examples & Verification", function() {
     testServer.stop();
   });
 
+  describe("GET requests", function() {
+    it("mounts hello world app", function() {
+      return request(testServer.express)
+        .get('/alexa/helloworld')
+        .expect(401);
+    });
 
-  it("mounts hello world app", function() {
-    return request(testServer.express)
-      .get('/alexa/helloworld')
-      .expect(401);
-  });
-
-  it("mounts number_guessing_game app", function() {
-    return request(testServer.express)
-      .get('/alexa/guessinggame')
-      .expect(401);
+    it("mounts number_guessing_game app", function() {
+      return request(testServer.express)
+        .get('/alexa/guessinggame')
+        .expect(401);
+    });
   });
 
   describe("POST requests", function() {
@@ -43,21 +44,14 @@ describe("Alexa App Server with Examples & Verification", function() {
       return request(testServer.express)
         .post('/alexa/helloworld')
         .send(sampleLaunchReq)
-        .expect(200);
+        .expect(401);
     });
 
     it("mounts number_guessing_game", function() {
       return request(testServer.express)
         .post('/alexa/guessinggame')
         .send(sampleLaunchReq)
-        .expect(200);
-    });
-
-    it("404s on an invalid app", function() {
-      return request(testServer.express)
-        .post('/alexa/invalid')
-        .send(sampleLaunchReq)
-        .expect(404);
+        .expect(401);
     });
   });
 });

--- a/test/test-examples-server.js
+++ b/test/test-examples-server.js
@@ -3,22 +3,23 @@
 var chai = require("chai");
 var expect = chai.expect;
 chai.config.includeStack = true;
-var request = require("supertest-as-promised");
-var fs = require('fs');
+var request = require("supertest");
 var alexaAppServer = require("../index");
+var fs = require("fs");
 
 describe("Alexa App Server with Examples", function() {
   var testServer;
-
-  var sampleLaunchReq = JSON.parse(fs.readFileSync("test/sample-launch-req.json", 'utf8'));
-  var sampleUtterances = fs.readFileSync("test/sample-utterances.txt", 'utf8');
-  var sampleSchema = fs.readFileSync("test/sample-schema.txt", 'utf8');
+  var sampleLaunchReq, sampleUtterances, sampleSchema;
 
   before(function() {
     testServer = alexaAppServer.start({
       port: 3000,
       server_root: 'examples'
     });
+
+    sampleLaunchReq = JSON.parse(fs.readFileSync("test/sample-launch-req.json", 'utf8'));
+    sampleUtterances = fs.readFileSync("test/sample-utterances.txt", 'utf8');
+    sampleSchema = fs.readFileSync("test/sample-schema.txt", 'utf8');
   });
 
   after(function() {
@@ -33,58 +34,64 @@ describe("Alexa App Server with Examples", function() {
       });
   });
 
-  it("mounts hello world app (GET)", function() {
-    return request(testServer.express)
-      .get('/alexa/helloworld')
-      .expect(200);
+  describe("GET requests", function() {
+    it("mounts hello world app", function() {
+      return request(testServer.express)
+        .get('/alexa/helloworld')
+        .expect(200);
+    });
+
+    it("mounts number_guessing_game", function() {
+      return request(testServer.express)
+        .get('/alexa/guessinggame')
+        .expect(200);
+    });
+
+    it("404s on an invalid app", function() {
+      return request(testServer.express)
+        .get('/alexa/invalid')
+        .expect(404);
+    });
   });
 
-  it("mounts hello world app (POST)", function() {
-    return request(testServer.express)
-      .post('/alexa/helloworld')
-      .send(sampleLaunchReq)
-      .expect(200);
+  describe("POST requests", function() {
+    it("mounts hello world app", function() {
+      return request(testServer.express)
+        .post('/alexa/helloworld')
+        .send(sampleLaunchReq)
+        .expect(200);
+    });
+
+    it("mounts number_guessing_game", function() {
+      return request(testServer.express)
+        .post('/alexa/guessinggame')
+        .send(sampleLaunchReq)
+        .expect(200);
+    });
+
+    it("404s on an invalid app", function() {
+      return request(testServer.express)
+        .post('/alexa/invalid')
+        .send(sampleLaunchReq)
+        .expect(404);
+    });
   });
 
-  it("mounts number_guessing_game (GET)", function() {
-    return request(testServer.express)
-      .get('/alexa/guessinggame')
-      .expect(200);
-  });
+  describe("schema and utterances", function() {
+    it("returns the schema of the hello world app", function() {
+      return request(testServer.express)
+        .get('/alexa/helloworld?schema')
+        .expect(200).then(function(res) {
+          expect(res.text).to.equal.sampleSchema;
+        });
+    });
 
-  it("mounts number_guessing_game (POST)", function() {
-    return request(testServer.express)
-      .post('/alexa/guessinggame')
-      .send(sampleLaunchReq)
-      .expect(200);
-  });
-
-  it("404s on an invalid app (GET)", function() {
-    return request(testServer.express)
-      .get('/alexa/invalid')
-      .expect(404);
-  });
-
-  it("404s on an invalid app (POST)", function() {
-    return request(testServer.express)
-      .post('/alexa/invalid')
-      .send(sampleLaunchReq)
-      .expect(404);
-  });
-
-  it("returns the schema of the hello world app", function() {
-    return request(testServer.express)
-      .get('/alexa/helloworld?schema')
-      .expect(200).then(function(res) {
-        expect(res.text).to.equal.sampleSchema;
-      });
-  });
-
-  it("returns the utterances of the hello world app", function() {
-    return request(testServer.express)
-      .get('/alexa/helloworld?utterances')
-      .expect(200).then(function(res) {
-        expect(res.text).to.equal.sampleUtterances;
-      });
+    it("returns the utterances of the hello world app", function() {
+      return request(testServer.express)
+        .get('/alexa/helloworld?utterances')
+        .expect(200).then(function(res) {
+          expect(res.text).to.equal.sampleUtterances;
+        });
+    });
   });
 });

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -3,7 +3,7 @@
 var chai = require("chai");
 var expect = chai.expect;
 chai.config.includeStack = true;
-var request = require("supertest-as-promised");
+var request = require("supertest");
 var alexaAppServer = require("../index");
 
 describe("Alexa App Server", function() {


### PR DESCRIPTION
* Removed deprecated dependency 'supertest-as-promised'
* Maintaining testing format consistency
* Added tests to verify that server does not always bind to both HTTP and HTTPS ports (#46)
* Added more node versions to run mocha tests on Travis-CI