### PR TITLE
Fix #52, #21 and #35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 2.3.2 (Next)
 
+* [#21](https://github.com/alexa-js/alexa-app-server/issues/21), [52](https://github.com/alexa-js/alexa-app-server/issues/52): Setting `verify: true` hangs for requests with signature - [@mreinstein](https://github.com/mreinstein), [@dblock](https://github.com/dblock).
 * [#61](https://github.com/alexa-js/alexa-app-server/pull/61): Fix: error occurs if HTTP and HTTPs ports specified are the same - [@dblock](https://github.com/dblock).
 * [#60](https://github.com/alexa-js/alexa-app-server/pull/60): Added `httpEnabled` that disables HTTP - [@dblock](https://github.com/dblock).
 * [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Added more node versions to run mocha tests on Travis-CI - [@tejashah88](https://github.com/tejashah88).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,16 @@
 
 ### 2.3.2 (Next)
 
+* [#35](https://github.com/alexa-js/alexa-app-server/issues/35): Removed `body-parser`, properly mounted by `alexa-app` - [@dblock](https://github.com/dblock).
 * [#21](https://github.com/alexa-js/alexa-app-server/issues/21), [52](https://github.com/alexa-js/alexa-app-server/issues/52): Setting `verify: true` hangs for requests with signature - [@mreinstein](https://github.com/mreinstein), [@dblock](https://github.com/dblock).
 * [#61](https://github.com/alexa-js/alexa-app-server/pull/61): Fix: error occurs if HTTP and HTTPs ports specified are the same - [@dblock](https://github.com/dblock).
 * [#60](https://github.com/alexa-js/alexa-app-server/pull/60): Added `httpEnabled` that disables HTTP - [@dblock](https://github.com/dblock).
-* [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Added more node versions to run mocha tests on Travis-CI - [@tejashah88](https://github.com/tejashah88).
-* [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Removed deprecated dependency 'supertest-as-promised' - [@tejashah88](https://github.com/tejashah88).
-* [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Added tests to verify that server does not always bind to both HTTP and HTTPS ports [#46](https://github.com/alexa-js/alexa-app-server/issues/46) - [@tejashah88](https://github.com/tejashah88).
-* [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Added more node versions to run mocha tests on Travis-CI - [@tejashah88](https://github.com/tejashah88).
+* [#48](https://github.com/alexa-js/alexa-app-server/pull/48): Removed deprecated dependency `supertest-as-promised` - [@tejashah88](https://github.com/tejashah88).
 * [#51](https://github.com/alexa-js/alexa-app-server/pull/51): Enable `strictHeaderCheck` in verifier middleware [#50](https://github.com/alexa-js/alexa-app-server/issues/50) - [@mreinstein](https://github.com/mreinstein).
-* [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added support for ca chain certificates [#17](https://github.com/alexa-js/alexa-app-server/pull/17) - [@tejashah88](https://github.com/tejashah88).
+* [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added support for CA chain certificates [#17](https://github.com/alexa-js/alexa-app-server/pull/17) - [@tejashah88](https://github.com/tejashah88).
 * [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added option to specify passphrase for unlocking specified SSL files - [@tejashah88](https://github.com/tejashah88).
 * [#45](https://github.com/alexa-js/alexa-app-server/pull/45): Added npm command to examine test coverage locally - [@tejashah88](https://github.com/tejashah88).
-* [#22](https://github.com/alexa-js/alexa-app-server/pull/22): Adding Context object to request templates + Refactored debugger files - [@pwbrown](https://github.com/pwbrown).
+* [#22](https://github.com/alexa-js/alexa-app-server/pull/22): Adding context object to request templates - [@pwbrown](https://github.com/pwbrown).
 * [#43](https://github.com/alexa-js/alexa-app-server/pull/43): Test fixes and an actual test for firing pre/post events. - [@dblock](https://github.com/dblock).
 * [#36](https://github.com/alexa-js/alexa-app-server/pull/36): Added option to specify host address to bind servers to - [@tejashah88](https://github.com/tejashah88).
 * [#35](https://github.com/alexa-js/alexa-app-server/pull/35): Error occurs when `verify` and `debug` are both set to true - [@tejashah88](https://github.com/tejashah88).
@@ -21,18 +19,15 @@
 * [#34](https://github.com/alexa-js/alexa-app-server/pull/34): Fixed bug while trying to retrieve schema/utterances with GET request - [@tejashah88](https://github.com/tejashah88).
 * [#34](https://github.com/alexa-js/alexa-app-server/pull/34): Updated messages that display an error to be displayed by `self.error` - [@tejashah88](https://github.com/tejashah88).
 * [#34](https://github.com/alexa-js/alexa-app-server/pull/34): Optimized some tests to not always start a new server instance after every test - [@tejashah88](https://github.com/tejashah88).
-* [#33](https://github.com/alexa-js/alexa-app-server/pull/33): Updated dependencies - [@tejashah88](https://github.com/tejashah88).
-* [#33](https://github.com/alexa-js/alexa-app-server/pull/33): Fix: expressjs deprecation warning - [@tejashah88](https://github.com/tejashah88).
+* [#33](https://github.com/alexa-js/alexa-app-server/pull/33): Fix: Express.js deprecation warning - [@tejashah88](https://github.com/tejashah88).
 * [#32](https://github.com/alexa-js/alexa-app-server/pull/32): Added tests for request verification, HTTPS support, and POST-based routes - [@tejashah88](https://github.com/tejashah88).
 * [#32](https://github.com/alexa-js/alexa-app-server/pull/32): Fix: potential memory leaks from not closing the HTTPS server instance and not removing the hotswap listeners - [@tejashah88](https://github.com/tejashah88).
-* [#32](https://github.com/alexa-js/alexa-app-server/pull/32): Use alexa-verifier-middleware for request verification - [@tejashah88](https://github.com/tejashah88).
-* [#32](https://github.com/alexa-js/alexa-app-server/pull/32): Moved 'sslcert' folder into examples - [@tejashah88](https://github.com/tejashah88).
+* [#32](https://github.com/alexa-js/alexa-app-server/pull/32): Use `alexa-verifier-middleware` for request verification - [@tejashah88](https://github.com/tejashah88).
+* [#32](https://github.com/alexa-js/alexa-app-server/pull/32): Moved `sslcert` folder into examples - [@tejashah88](https://github.com/tejashah88).
 * [#32](https://github.com/alexa-js/alexa-app-server/pull/32): Updated documentation for generating the SSL certificate - [@tejashah88](https://github.com/tejashah88).
 * [#28](https://github.com/alexa-js/alexa-app-server/pull/28): Moved to the [alexa-js organization](https://github.com/alexa-js) - [@dblock](https://github.com/dblock).
 * [#23](https://github.com/alexa-js/alexa-app-server/pull/23): Added `server.stop()` - [@dblock](https://github.com/dblock).
-* [#23](https://github.com/alexa-js/alexa-app-server/pull/23): Added LICENSE - [@dblock](https://github.com/dblock).
-* [#23](https://github.com/alexa-js/alexa-app-server/pull/23): Added tests - [@dblock](https://github.com/dblock).
-* [#29](https://github.com/alexa-js/alexa-app-server/pull/29): Added code coverage - [@dblock](https://github.com/dblock).
+* [#23](https://github.com/alexa-js/alexa-app-server/pull/23): Added tests, code coverage and LICENSE - [@dblock](https://github.com/dblock).
 * [#27](https://github.com/alexa-js/alexa-app-server/pull/27): Added Danger, PR linter - [@dblock](https://github.com/dblock).
 * Your contribution here.
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var http = require('http');
 var https = require('https');
 var express = require('express');
 var alexa = require('alexa-app');
-var bodyParser = require('body-parser');
 var Promise = require('bluebird');
 var defaults = require("lodash.defaults");
 
@@ -152,10 +151,6 @@ var appServer = function(config) {
     // TODO: add i18n support (i18n-node might be a good look)
     // Issue #12: https://github.com/alexa-js/alexa-app-server/issues/12
     self.express = express();
-
-    // TODO: change this to make sure it doesn't affect other non-Alexa services/apps
-    // Issue #35: https://github.com/alexa-js/alexa-app-server/issues/35
-    self.express.use(bodyParser.urlencoded({ extended: true }));
 
     self.express.set('views', path.join(__dirname, 'views'));
     self.express.set('view engine', 'ejs');

--- a/index.js
+++ b/index.js
@@ -118,7 +118,9 @@ var appServer = function(config) {
                 expressApp: alexaRouter,
                 router: express.Router(),
                 debug: config.debug,
-                checkCert: config.verify
+                checkCert: config.verify,
+                preRequest: config.preRequest,
+                postRequest: config.postRequest
             });
 
             self.log("   loaded app [" + pkg.name + "] at endpoint: " + normalizedRoot + "/" + pkg.name);

--- a/index.js
+++ b/index.js
@@ -10,294 +10,294 @@ var Promise = require('bluebird');
 var defaults = require("lodash.defaults");
 
 var appServer = function(config) {
-    var self = {};
-    config = config || {};
+  var self = {};
+  config = config || {};
 
-    var defaultOptions = {
-        log: true,
-        debug: true,
-        verify: false,
-        port: process.env.port || 8080,
-        httpEnabled: true,
-        httpsEnabled: false,
-        server_root: ''
+  var defaultOptions = {
+    log: true,
+    debug: true,
+    verify: false,
+    port: process.env.port || 8080,
+    httpEnabled: true,
+    httpsEnabled: false,
+    server_root: ''
+  };
+
+  config = defaults(config, defaultOptions);
+
+  if (config.verify && config.debug) {
+    throw new Error("invalid configuration: the verify and debug options cannot be both enabled");
+  }
+
+  if (config.httpEnabled == false && config.httpsEnabled == false) {
+    throw new Error("invalid configuration: either http or https must be enabled");
+  }
+
+  if (config.httpEnabled && config.httpsEnabled && config.port == config.httpsPort) {
+    throw new Error("invalid configuration: http and https ports must be different");
+  }
+
+  self.apps = {};
+
+  self.log = function(msg) {
+    if (config.log) {
+      console.log(msg);
+    }
+  };
+  self.error = function(msg) {
+    console.error(msg);
+  };
+
+  // Configure hotswap to watch for changes and swap out module code
+  var hotswapCallback = function(filename) {
+    self.log("hotswap reloaded " + filename);
+  };
+
+  var errorCallback = function(e) {
+    self.error("-----\nhotswap error: " + e + "\n-----\n");
+  };
+
+  hotswap.on('swap', hotswapCallback);
+  hotswap.on('error', errorCallback);
+
+  // Load application modules
+  self.load_apps = function(app_dir, root) {
+    // set up a router to hang all alexa apps off of
+    var alexaRouter = express.Router();
+
+    var normalizedRoot = root.indexOf('/') === 0 ? root : '/' + root;
+    self.express.use(normalizedRoot, alexaRouter);
+
+    var app_directories = function(srcpath) {
+      return fs.readdirSync(srcpath).filter(function(file) {
+        return fs.statSync(path.join(srcpath, file)).isDirectory();
+      });
     };
 
-    config = defaults(config, defaultOptions);
+    app_directories(app_dir).forEach(function(dir) {
+      var package_json = path.join(app_dir, dir, "/package.json");
+      if (!fs.existsSync(package_json) || !fs.statSync(package_json).isFile()) {
+        self.error("   package.json not found in directory " + dir);
+        return;
+      }
 
-    if (config.verify && config.debug) {
-        throw new Error("invalid configuration: the verify and debug options cannot be both enabled");
+      var pkg = JSON.parse(fs.readFileSync(package_json, 'utf8'));
+      if (!pkg || !pkg.main || !pkg.name) {
+        self.error("   failed to load " + package_json);
+        return;
+      }
+
+      var main = fs.realpathSync(path.join(app_dir, dir, pkg.main));
+      if (!fs.existsSync(main) || !fs.statSync(main).isFile()) {
+        self.error("   main file not found for app [" + pkg.name + "]: " + main);
+        return;
+      }
+
+      var app;
+      try {
+        app = require(main);
+      } catch (e) {
+        self.error("   error loading app [" + main + "]: " + e);
+        return;
+      }
+
+      self.apps[pkg.name] = pkg;
+      self.apps[pkg.name].exports = app;
+      if (typeof app.express != "function") {
+        self.error("   app [" + pkg.name + "] is not an instance of alexa-app");
+        return;
+      }
+
+      // Extract Alexa-specific attributes from package.json, if they exist
+      if (typeof pkg.alexa == "object") {
+        app.id = pkg.alexa.applicationId;
+      }
+
+      // attach the alexa-app instance to the alexa router
+      app.express({
+        expressApp: alexaRouter,
+        router: express.Router(),
+        debug: config.debug,
+        checkCert: config.verify,
+        preRequest: config.preRequest,
+        postRequest: config.postRequest
+      });
+
+      self.log("   loaded app [" + pkg.name + "] at endpoint: " + normalizedRoot + "/" + pkg.name);
+    });
+
+    return self.apps;
+  };
+
+  // Load server modules. For example, code the process forms, etc. Anything that
+  // wants to hook into express
+  self.load_server_modules = function(server_dir) {
+    var server_files = function(srcpath) {
+      return fs.readdirSync(srcpath).filter(function(file) {
+        return fs.statSync(path.join(srcpath, file)).isFile();
+      });
+    };
+    server_files(server_dir).forEach(function(file) {
+      file = fs.realpathSync(path.join(server_dir, file));
+      self.log("   loaded " + file);
+      var func = require(file);
+      if (typeof func == "function") {
+        func(self.express, self);
+      }
+    });
+  };
+
+  self.start = function() {
+    // Instantiate up the server
+    // TODO: add i18n support (i18n-node might be a good look)
+    // Issue #12: https://github.com/alexa-js/alexa-app-server/issues/12
+    self.express = express();
+
+    // TODO: change this to make sure it doesn't affect other non-Alexa services/apps
+    // Issue #35: https://github.com/alexa-js/alexa-app-server/issues/35
+    self.express.use(bodyParser.urlencoded({ extended: true }));
+
+    self.express.set('views', path.join(__dirname, 'views'));
+    self.express.set('view engine', 'ejs');
+    self.express.use(express.static(path.join(__dirname, 'views')));
+
+    // Run the pre() method if defined
+    if (typeof config.pre == "function") {
+      config.pre(self);
     }
 
-    if (config.httpEnabled == false && config.httpsEnabled == false) {
-        throw new Error("invalid configuration: either http or https must be enabled");
+    // Serve static content
+    var static_dir = path.join(config.server_root, config.public_html || 'public_html');
+    if (fs.existsSync(static_dir) && fs.statSync(static_dir).isDirectory()) {
+      self.log("serving static content from: " + static_dir);
+      self.express.use(express.static(static_dir));
+    } else {
+      self.log("not serving static content because directory [" + static_dir + "] does not exist");
     }
 
-    if (config.httpEnabled && config.httpsEnabled && config.port == config.httpsPort) {
-        throw new Error("invalid configuration: http and https ports must be different");
+    // Find any server-side processing modules and let them hook in
+    var server_dir = path.join(config.server_root, config.server_dir || 'server');
+    if (fs.existsSync(server_dir) && fs.statSync(server_dir).isDirectory()) {
+      self.log("loading server-side modules from: " + server_dir);
+      self.load_server_modules(server_dir);
+    } else {
+      self.log("no server modules loaded because directory [" + server_dir + "] does not exist");
     }
 
-    self.apps = {};
+    // Find and load alexa-app modules
+    var app_dir = path.join(config.server_root, config.app_dir || 'apps');
+    if (fs.existsSync(app_dir) && fs.statSync(app_dir).isDirectory()) {
+      self.log("loading apps from: " + app_dir);
+      self.load_apps(app_dir, config.app_root || '/alexa');
+    } else {
+      self.log("apps not loaded because directory [" + app_dir + "] does not exist");
+    }
 
-    self.log = function(msg) {
-        if (config.log) {
-            console.log(msg);
-        }
-    };
-    self.error = function(msg) {
-        console.error(msg);
-    };
+    if (config.httpsEnabled == true) {
+      self.log("enabling https");
 
-    // Configure hotswap to watch for changes and swap out module code
-    var hotswapCallback = function(filename) {
-        self.log("hotswap reloaded " + filename);
-    };
+      if (config.privateKey != undefined && config.certificate != undefined && config.httpsPort != undefined) { // Ensure that all of the needed properties are set
+        var privateKeyFile = config.server_root + '/sslcert/' + config.privateKey;
+        var certificateFile = config.server_root + '/sslcert/' + config.certificate;
+        var chainFile = (config.chain != undefined) ? config.server_root + '/sslcert/' + config.chain : undefined; //optional chain bundle
 
-    var errorCallback = function(e) {
-        self.error("-----\nhotswap error: " + e + "\n-----\n");
-    };
+        if (fs.existsSync(privateKeyFile) && fs.existsSync(certificateFile)) { // Make sure the key and cert exist.
+          var privateKey = fs.readFileSync(privateKeyFile, 'utf8');
+          var certificate = fs.readFileSync(certificateFile, 'utf8');
 
-    hotswap.on('swap', hotswapCallback);
-    hotswap.on('error', errorCallback);
-
-    // Load application modules
-    self.load_apps = function(app_dir, root) {
-        // set up a router to hang all alexa apps off of
-        var alexaRouter = express.Router();
-
-        var normalizedRoot = root.indexOf('/') === 0 ? root : '/' + root;
-        self.express.use(normalizedRoot, alexaRouter);
-
-        var app_directories = function(srcpath) {
-            return fs.readdirSync(srcpath).filter(function(file) {
-                return fs.statSync(path.join(srcpath, file)).isDirectory();
-            });
-        };
-
-        app_directories(app_dir).forEach(function(dir) {
-            var package_json = path.join(app_dir, dir, "/package.json");
-            if (!fs.existsSync(package_json) || !fs.statSync(package_json).isFile()) {
-                self.error("   package.json not found in directory " + dir);
-                return;
-            }
-
-            var pkg = JSON.parse(fs.readFileSync(package_json, 'utf8'));
-            if (!pkg || !pkg.main || !pkg.name) {
-                self.error("   failed to load " + package_json);
-                return;
-            }
-
-            var main = fs.realpathSync(path.join(app_dir, dir, pkg.main));
-            if (!fs.existsSync(main) || !fs.statSync(main).isFile()) {
-                self.error("   main file not found for app [" + pkg.name + "]: " + main);
-                return;
-            }
-
-            var app;
-            try {
-                app = require(main);
-            } catch (e) {
-                self.error("   error loading app [" + main + "]: " + e);
-                return;
-            }
-
-            self.apps[pkg.name] = pkg;
-            self.apps[pkg.name].exports = app;
-            if (typeof app.express != "function") {
-                self.error("   app [" + pkg.name + "] is not an instance of alexa-app");
-                return;
-            }
-
-            // Extract Alexa-specific attributes from package.json, if they exist
-            if (typeof pkg.alexa == "object") {
-                app.id = pkg.alexa.applicationId;
-            }
-
-            // attach the alexa-app instance to the alexa router
-            app.express({
-                expressApp: alexaRouter,
-                router: express.Router(),
-                debug: config.debug,
-                checkCert: config.verify,
-                preRequest: config.preRequest,
-                postRequest: config.postRequest
-            });
-
-            self.log("   loaded app [" + pkg.name + "] at endpoint: " + normalizedRoot + "/" + pkg.name);
-        });
-
-        return self.apps;
-    };
-
-    // Load server modules. For example, code the process forms, etc. Anything that
-    // wants to hook into express
-    self.load_server_modules = function(server_dir) {
-        var server_files = function(srcpath) {
-            return fs.readdirSync(srcpath).filter(function(file) {
-                return fs.statSync(path.join(srcpath, file)).isFile();
-            });
-        };
-        server_files(server_dir).forEach(function(file) {
-            file = fs.realpathSync(path.join(server_dir, file));
-            self.log("   loaded " + file);
-            var func = require(file);
-            if (typeof func == "function") {
-                func(self.express, self);
-            }
-        });
-    };
-
-    self.start = function() {
-        // Instantiate up the server
-        // TODO: add i18n support (i18n-node might be a good look)
-        // Issue #12: https://github.com/alexa-js/alexa-app-server/issues/12
-        self.express = express();
-
-        // TODO: change this to make sure it doesn't affect other non-Alexa services/apps
-        // Issue #35: https://github.com/alexa-js/alexa-app-server/issues/35
-        self.express.use(bodyParser.urlencoded({ extended: true }));
-
-        self.express.set('views', path.join(__dirname, 'views'));
-        self.express.set('view engine', 'ejs');
-        self.express.use(express.static(path.join(__dirname, 'views')));
-
-        // Run the pre() method if defined
-        if (typeof config.pre == "function") {
-            config.pre(self);
-        }
-
-        // Serve static content
-        var static_dir = path.join(config.server_root, config.public_html || 'public_html');
-        if (fs.existsSync(static_dir) && fs.statSync(static_dir).isDirectory()) {
-            self.log("serving static content from: " + static_dir);
-            self.express.use(express.static(static_dir));
-        } else {
-            self.log("not serving static content because directory [" + static_dir + "] does not exist");
-        }
-
-        // Find any server-side processing modules and let them hook in
-        var server_dir = path.join(config.server_root, config.server_dir || 'server');
-        if (fs.existsSync(server_dir) && fs.statSync(server_dir).isDirectory()) {
-            self.log("loading server-side modules from: " + server_dir);
-            self.load_server_modules(server_dir);
-        } else {
-            self.log("no server modules loaded because directory [" + server_dir + "] does not exist");
-        }
-
-        // Find and load alexa-app modules
-        var app_dir = path.join(config.server_root, config.app_dir || 'apps');
-        if (fs.existsSync(app_dir) && fs.statSync(app_dir).isDirectory()) {
-            self.log("loading apps from: " + app_dir);
-            self.load_apps(app_dir, config.app_root || '/alexa');
-        } else {
-            self.log("apps not loaded because directory [" + app_dir + "] does not exist");
-        }
-
-        if (config.httpsEnabled == true) {
-            self.log("enabling https");
-
-            if (config.privateKey != undefined && config.certificate != undefined && config.httpsPort != undefined) { // Ensure that all of the needed properties are set
-                var privateKeyFile = config.server_root + '/sslcert/' + config.privateKey;
-                var certificateFile = config.server_root + '/sslcert/' + config.certificate;
-                var chainFile = (config.chain != undefined) ? config.server_root + '/sslcert/' + config.chain : undefined; //optional chain bundle
-
-                if (fs.existsSync(privateKeyFile) && fs.existsSync(certificateFile)) { // Make sure the key and cert exist.
-                    var privateKey = fs.readFileSync(privateKeyFile, 'utf8');
-                    var certificate = fs.readFileSync(certificateFile, 'utf8');
-
-                    var chain = undefined;
-                    if (chainFile != undefined) {
-                        if (fs.existsSync(chainFile)) {
-                            chain = fs.readFileSync(chainFile, 'utf8');
-                        } else {
-                            self.error("chain: '" + config.chain + "' does not exist in /sslcert");
-                        }
-                    }
-
-                    if (chain == undefined && chainFile != undefined) {
-                        self.error("failed to load chain from /sslcert, https will not be enabled");
-                    } else if (privateKey != undefined && certificate != undefined) {
-                        var credentials = {
-                            key: privateKey,
-                            cert: certificate
-                        };
-
-                        if (config.passphrase != undefined) {
-                            credentials.passphrase = config.passphrase
-                        }
-
-                        if (chain != undefined) { //if chain is used the add to credentials
-                            credentials.ca = chain;
-                            self.log("using chain certificate from /sslcert");
-                        }
-
-                        try { // These two lines below can fail it the certs were generated incorrectly. But we can continue startup without HTTPS
-                            var httpsServer = https.createServer(credentials, self.express); // create the HTTPS server
-
-                            // TODO: add separate option to specify specific host address for HTTPS server to bind to???
-                            // Issue #38: https://github.com/alexa-js/alexa-app-server/issues/38
-                            if (typeof config.host === 'string') {
-                                self.httpsInstance = httpsServer.listen(config.httpsPort, config.host);
-                                self.log("listening on https://" + config.host + ":" + config.httpsPort);
-                            } else {
-                                self.httpsInstance = httpsServer.listen(config.httpsPort);
-                                self.log("listening on https port " + config.httpsPort);
-                            }
-                        } catch (error) {
-                            self.error("failed to listen via https: " + error);
-                        }
-                    } else {
-                        self.error("failed to load privateKey or certificate from /sslcert, https will not be enabled");
-                    }
-                } else {
-                    self.error("privateKey: '" + config.privateKey + "' or certificate: '" + config.certificate + "' do not exist in /sslcert, https will not be enabled");
-                }
+          var chain = undefined;
+          if (chainFile != undefined) {
+            if (fs.existsSync(chainFile)) {
+              chain = fs.readFileSync(chainFile, 'utf8');
             } else {
-                self.error("httpsPort, privateKey or certificate parameter is not set in config, https will not be enabled");
+              self.error("chain: '" + config.chain + "' does not exist in /sslcert");
             }
-        }
+          }
 
-        if (config.httpEnabled) {
-            if (typeof config.host === 'string') {
-                self.instance = self.express.listen(config.port, config.host);
-                self.log("listening on http://" + config.host + ":" + config.port);
-            } else {
-                self.instance = self.express.listen(config.port);
-                self.log("listening on http port " + config.port);
+          if (chain == undefined && chainFile != undefined) {
+            self.error("failed to load chain from /sslcert, https will not be enabled");
+          } else if (privateKey != undefined && certificate != undefined) {
+            var credentials = {
+              key: privateKey,
+              cert: certificate
+            };
+
+            if (config.passphrase != undefined) {
+              credentials.passphrase = config.passphrase
             }
+
+            if (chain != undefined) { //if chain is used the add to credentials
+              credentials.ca = chain;
+              self.log("using chain certificate from /sslcert");
+            }
+
+            try { // These two lines below can fail it the certs were generated incorrectly. But we can continue startup without HTTPS
+              var httpsServer = https.createServer(credentials, self.express); // create the HTTPS server
+
+              // TODO: add separate option to specify specific host address for HTTPS server to bind to???
+              // Issue #38: https://github.com/alexa-js/alexa-app-server/issues/38
+              if (typeof config.host === 'string') {
+                self.httpsInstance = httpsServer.listen(config.httpsPort, config.host);
+                self.log("listening on https://" + config.host + ":" + config.httpsPort);
+              } else {
+                self.httpsInstance = httpsServer.listen(config.httpsPort);
+                self.log("listening on https port " + config.httpsPort);
+              }
+            } catch (error) {
+              self.error("failed to listen via https: " + error);
+            }
+          } else {
+            self.error("failed to load privateKey or certificate from /sslcert, https will not be enabled");
+          }
+        } else {
+          self.error("privateKey: '" + config.privateKey + "' or certificate: '" + config.certificate + "' do not exist in /sslcert, https will not be enabled");
         }
+      } else {
+        self.error("httpsPort, privateKey or certificate parameter is not set in config, https will not be enabled");
+      }
+    }
 
-        // Run the post() method if defined
-        if (typeof config.post == "function") {
-            config.post(self);
-        }
+    if (config.httpEnabled) {
+      if (typeof config.host === 'string') {
+        self.instance = self.express.listen(config.port, config.host);
+        self.log("listening on http://" + config.host + ":" + config.port);
+      } else {
+        self.instance = self.express.listen(config.port);
+        self.log("listening on http port " + config.port);
+      }
+    }
 
-        return this;
-    };
+    // Run the post() method if defined
+    if (typeof config.post == "function") {
+      config.post(self);
+    }
 
-    self.stop = function() {
-        // close all server instances
-        if (typeof self.instance !== "undefined") {
-            self.instance.close();
-        }
+    return this;
+  };
 
-        if (typeof self.httpsInstance !== "undefined") {
-            self.httpsInstance.close();
-        }
+  self.stop = function() {
+    // close all server instances
+    if (typeof self.instance !== "undefined") {
+      self.instance.close();
+    }
 
-        // deactivate all hotswap listener
-        hotswap.removeListener('swap', hotswapCallback);
-        hotswap.removeListener('error', errorCallback);
-    };
+    if (typeof self.httpsInstance !== "undefined") {
+      self.httpsInstance.close();
+    }
 
-    return self;
+    // deactivate all hotswap listener
+    hotswap.removeListener('swap', hotswapCallback);
+    hotswap.removeListener('error', errorCallback);
+  };
+
+  return self;
 };
 
 // A shortcut start(config) method to avoid creating an instance if not needed
 appServer.start = function(config) {
-    var appServerInstance = new appServer(config);
-    appServerInstance.start();
-    return appServerInstance;
+  var appServerInstance = new appServer(config);
+  appServerInstance.start();
+  return appServerInstance;
 };
 
 module.exports = appServer;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "alexa-app": "dblock/alexa-app#test-app-schema-utterances",
+    "alexa-app": "alexa-js/alexa-app",
     "alexa-verifier-middleware": "^0.1.8",
     "bluebird": "^3.4.7",
     "body-parser": "~1.16.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "alexa-app": "^2.4.0",
+    "alexa-app": "dblock/alexa-app#test-app-schema-utterances",
     "alexa-verifier-middleware": "^0.1.8",
     "bluebird": "^3.4.7",
     "body-parser": "~1.16.0",

--- a/test/test-examples-server-verification.js
+++ b/test/test-examples-server-verification.js
@@ -54,5 +54,23 @@ describe("Alexa App Server with Examples & Verification", function() {
         .send(sampleLaunchReq)
         .expect(401);
     });
+
+    it("invokes verifier number_guessing_game", function() {
+      return request(testServer.express)
+        .post('/alexa/number_guessing_game')
+        .set('signaturecertchainurl', 'dummy-signature-chain-url')
+        .set('signature', 'dummy-signature')
+        .send(sampleLaunchReq)
+        .expect(401);
+    });
+
+    it("invokes verifier number_guessing_game", function() {
+      return request(testServer.express)
+        .post('/alexa/number_guessing_game')
+        .set('signaturecertchainurl', 'dummy-signature-chain-url')
+        .set('signature', 'dummy-signature')
+        .send(sampleLaunchReq)
+        .expect(401);
+    });
   });
 });

--- a/views/test.ejs
+++ b/views/test.ejs
@@ -10,7 +10,7 @@
       function clone(o) {
         return JSON.parse(JSON.stringify(o));
       }
-      
+
       // For Angular
       var app = angular.module('alexa', []);
       app.controller('AlexaController', function($scope, $http) {
@@ -113,7 +113,7 @@
         Intent:
         <select id="intent_select" ng-change="changeintent()" ng-model="intent">
           <option value="">
-          <% for (name in intents) { %>
+          <% for (name in app.intents) { %>
             <option value="<%=name%>"><%=name%>
           <% } %>
         </select>
@@ -149,11 +149,6 @@
     <h2>Schema</h2>
     <div>
       <div id="schema" class="code">{{schema|json}}</div>
-    </div>
-
-    <h2>Custom Slot Types</h2>
-    <div>
-      <div id="customSlotTypes" class="code" style="max-height:500px;overflow:auto;"><%=customSlotTypes%></div>
     </div>
 
     <h2>Utterances</h2>


### PR DESCRIPTION
@mreinstein correctly calls that #54 fixes #52, #21 and partially #35. What this does is use alexa-app's `express` method instead of cooking our own, plus a test that right now would hang on master and no longer hangs in this branch.

Replaces https://github.com/alexa-js/alexa-app-server/pull/56 on top of #60.

This is dependent on https://github.com/alexa-js/alexa-app/pull/150, I didn't find a better way to get `?utterances`, `?schema` and `preRequest` and `postRequest` support without moving this logic upstream to alexa-app.


 

 