### PR TITLE
Fixed the endpoint message to use app.name to match the endpoint route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 * [#71](https://github.com/alexa-js/alexa-app-server/pull/71), [#68](https://github.com/alexa-js/alexa-app-server/issues/68): Fixed log output containing multiple slashes - [@tejashah88](https://github.com/tejashah88).
 * [#72](https://github.com/alexa-js/alexa-app-server/pull/72): Use `path.join` for constructing relative paths - [@dblock](https://github.com/dblock).
 * [#74](https://github.com/alexa-js/alexa-app-server/pull/74): Added locale selector to test page - [@siedi](https://github.com/siedi).
-* Changed endpoint message to use app name to match route
-[@zweiler](https://github.com/zweiler)
+* [#76](https://github.com/alexa-js/alexa-app-server/pull/76): Changed endpoint message to use app name to match route - [@zweiler](https://github.com/zweiler).
 * Your contribution here.
 
 ### 3.0.0 (February 6, 2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * [#71](https://github.com/alexa-js/alexa-app-server/pull/71), [#68](https://github.com/alexa-js/alexa-app-server/issues/68): Fixed log output containing multiple slashes - [@tejashah88](https://github.com/tejashah88).
 * [#72](https://github.com/alexa-js/alexa-app-server/pull/72): Use `path.join` for constructing relative paths - [@dblock](https://github.com/dblock).
 * [#74](https://github.com/alexa-js/alexa-app-server/pull/74): Added locale selector to test page - [@siedi](https://github.com/siedi).
+* Changed endpoint message to use app name to match route
+[@zweiler](https://github.com/zweiler)
 * Your contribution here.
 
 ### 3.0.0 (February 6, 2017)

--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ var appServer = function(config) {
         postRequest: self.config.postRequest
       });
 
-      var endpoint = path.posix.join(normalizedRoot, pkg.name);
+      var endpoint = path.posix.join(normalizedRoot, app.name);
       self.log("   loaded app [" + pkg.name + "] at endpoint: " + endpoint);
     });
 

--- a/invalid_examples/apps/bad_app_name_mismatch/index.js
+++ b/invalid_examples/apps/bad_app_name_mismatch/index.js
@@ -1,0 +1,11 @@
+var alexa = require('alexa-app');
+
+// Allow this module to be reloaded by hotswap when changed
+module.change_code = 1;
+
+// Define an alexa-app
+var app = new alexa.app('bad_app_name_mismatch');
+app.launch(function(req,res) {
+	res.say("This app should message the app name endpoint, not the package.json name");
+});
+module.exports = app;

--- a/invalid_examples/apps/bad_app_name_mismatch/package.json
+++ b/invalid_examples/apps/bad_app_name_mismatch/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bad_app_name-mismatch",
+  "version": "1.0.0",
+  "description": "A sample Alexa app",
+  "main": "index.js",
+  "author": "Matt Kruse <github@mattkruse.com> (http://mattkruse.com/)",
+  "license": "ISC",
+  "alexa": {
+    "applicationId":"amzn1.echo-sdk-ams.app.999999-d0ed-9999-ad00-999999d00ebe"
+  },
+  "dependencies": {
+    "alexa-app": "^2.1.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
     "lodash.defaults": "^4.2.0"
   },
   "devDependencies": {
-    "mocha": "^3.2.0",
     "chai": "^3.5.0",
-    "supertest": "^3.0.0",
-    "istanbul": "0.4.5",
     "coveralls": "^2.11.15",
     "danger": "0.11.4",
+    "istanbul": "0.4.5",
+    "mocha": "^3.2.0",
+    "sinon": "^1.17.7",
+    "sinon-chai": "^2.8.0",
+    "supertest": "^3.0.0",
     "tcp-port-used": "0.1.2"
   }
 }

--- a/test/test-examples-server-app-loading-fail-checks.js
+++ b/test/test-examples-server-app-loading-fail-checks.js
@@ -14,10 +14,22 @@ describe("Alexa App Server with invalid examples", function() {
 
   afterEach(function() {
     testServer.stop();
-    console.log.restore();
   });
 
   it("starts without loading invalid apps", function() {
+    testServer = alexaAppServer.start({
+      port: 3000,
+      server_root: 'invalid_examples'
+    });
+
+    return request(testServer.express)
+      .get('/')
+      .expect(200).then(function(response) {
+        expect(response.text).to.contain("alexa-app-server is running");
+      });
+  });
+
+  it("loads apps with the app name in the endpoint message", function() {
     sinon.spy(console, 'log');
     testServer = alexaAppServer.start({
       port: 3000,
@@ -27,10 +39,6 @@ describe("Alexa App Server with invalid examples", function() {
     var badAppNameMismatch = '   loaded app [bad_app_name-mismatch] at endpoint: /alexa/bad_app_name_mismatch';
     expect(console.log).to.have.been.calledWithExactly(badAppNameMismatch);
 
-    return request(testServer.express)
-      .get('/')
-      .expect(200).then(function(response) {
-        expect(response.text).to.contain("alexa-app-server is running");
-      });
+    console.log.restore();
   });
 });

--- a/test/test-examples-server-app-loading-fail-checks.js
+++ b/test/test-examples-server-app-loading-fail-checks.js
@@ -1,6 +1,9 @@
 /*jshint expr: true*/
 "use strict";
 var chai = require("chai");
+var sinon = require("sinon");
+var sinonChai = require("sinon-chai");
+chai.use(sinonChai);
 var expect = chai.expect;
 chai.config.includeStack = true;
 var request = require("supertest");
@@ -11,13 +14,18 @@ describe("Alexa App Server with invalid examples", function() {
 
   afterEach(function() {
     testServer.stop();
+    console.log.restore();
   });
 
   it("starts without loading invalid apps", function() {
+    sinon.spy(console, 'log');
     testServer = alexaAppServer.start({
       port: 3000,
       server_root: 'invalid_examples'
     });
+
+    var badAppNameMismatch = '   loaded app [bad_app_name-mismatch] at endpoint: /alexa/bad_app_name_mismatch';
+    expect(console.log).to.have.been.calledWithExactly(badAppNameMismatch);
 
     return request(testServer.express)
       .get('/')


### PR DESCRIPTION
A minor thing, but something that stymied me for a while when I started using the package. The "loaded app at endpoiont" message is inaccurate if the package.json name and the name used in the Alexa app constructor are different. Changed the message to use the app name, which is where the endpoint actually is. 

Happy to flip this as well, and change the router to use the package.json name.