### PR TITLE
Remove router from `app.express()` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#72](https://github.com/alexa-js/alexa-app-server/pull/72): Use `path.join` for constructing relative paths - [@dblock](https://github.com/dblock).
 * [#74](https://github.com/alexa-js/alexa-app-server/pull/74): Added locale selector to test page - [@siedi](https://github.com/siedi).
 * [#76](https://github.com/alexa-js/alexa-app-server/pull/76): Changed endpoint message to use app name to match route - [@zweiler](https://github.com/zweiler).
+* [#79](https://github.com/alexa-js/alexa-app-server/pull/77): Removed router from `app.express()` configuration options - [@rickwargo](https://github.com/rickwargo).
 * Your contribution here.
 
 ### 3.0.0 (February 6, 2017)

--- a/index.js
+++ b/index.js
@@ -121,7 +121,6 @@ var appServer = function(config) {
       // attach the alexa-app instance to the alexa router
       app.express({
         expressApp: alexaRouter,
-        router: express.Router(),
         debug: self.config.debug,
         checkCert: self.config.verify,
         preRequest: self.config.preRequest,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "alexa-app": "^3.0.0",
+    "alexa-app": "^3.2.0",
     "bluebird": "^3.4.7",
     "body-parser": "~1.16.0",
     "ejs": "~2.5.5",

--- a/test/test-examples-server-https-fail-checks.js
+++ b/test/test-examples-server-https-fail-checks.js
@@ -76,7 +76,7 @@ describe("Alexa App Server with Examples & HTTPS fail checking", function() {
   });
 
   // binding to port -1 seems to behave differently on versions of node < 6
-  it("fails to mount due to invalid port", function() {
+  xit("fails to mount due to invalid port", function() {
     testServer = alexaAppServer.start({
       httpsPort: -1,
       server_root: 'invalid_examples',

--- a/test/test-examples-server-https-fail-checks.js
+++ b/test/test-examples-server-https-fail-checks.js
@@ -76,7 +76,7 @@ describe("Alexa App Server with Examples & HTTPS fail checking", function() {
   });
 
   // binding to port -1 seems to behave differently on versions of node < 6
-  xit("fails to mount due to invalid port", function() {
+  it("fails to mount due to invalid port", function() {
     testServer = alexaAppServer.start({
       httpsPort: -1,
       server_root: 'invalid_examples',


### PR DESCRIPTION
alexa-app now deprecates simultaneous use of both `expressApp` and `router` in `app.express()` and generates the following warning:
```
Usage deprecated: Both 'expressApp' and 'router' are specified.
More details on https://github.com/alexa-js/alexa-app/blob/master/UPGRADING.md
```
Removing router option from config brings the app-server up-to-date with alexa-app.