### PR TITLE
Support additional request properties in test page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ Temporary Items
 
 # Code Coverage
 coverage
+
+# IDEs
+.vs
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
         - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 
 node_js:
-  - 0.12
   - 1
   - 2
   - 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 3.0.2 (Next)
 
 * Your contribution here.
+* [#88](https://github.com/alexa-js/alexa-app-server/pull/88): No longer compatible with Node 0.12 - [@martincostello](https://github.com/martincostello).
 * [#88](https://github.com/alexa-js/alexa-app-server/pull/88): Added access token, consent token, device ID and API endpoint to test page - [@martincostello](https://github.com/martincostello).
 * [#84](https://github.com/alexa-js/alexa-app-server/pull/84), [#73](https://github.com/alexa-js/alexa-app-server/issues/73): Changed default server_root to `__dirname` - [@benedekh](https://github.com/benedekh).
 * [#83](https://github.com/alexa-js/alexa-app-server/pull/83), [#77](https://github.com/alexa-js/alexa-app-server/issues/77): Fixed Application ID not getting set in tests - [@benedekh](https://github.com/benedekh).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 3.0.2 (Next)
 
 * Your contribution here.
+* [#88](https://github.com/alexa-js/alexa-app-server/pull/88): Added access token, consent token, device ID and API endpoint to test page - [@martincostello](https://github.com/martincostello).
 * [#84](https://github.com/alexa-js/alexa-app-server/pull/84), [#73](https://github.com/alexa-js/alexa-app-server/issues/73): Changed default server_root to `__dirname` - [@benedekh](https://github.com/benedekh).
 * [#83](https://github.com/alexa-js/alexa-app-server/pull/83), [#77](https://github.com/alexa-js/alexa-app-server/issues/77): Fixed Application ID not getting set in tests - [@benedekh](https://github.com/benedekh).
 

--- a/views/templates.json
+++ b/views/templates.json
@@ -9,7 +9,11 @@ templates = {
 			},
 			"attributes": {},
 			"user": {
-				"userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+				"userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2",
+				"permissions": {
+					"consentToken": null
+				},
+				"accessToken": null
 			}
 		},
 		"context": {
@@ -18,13 +22,19 @@ templates = {
 					"applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
 				},
 				"user": {
-					"userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+					"userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2",
+					"permissions": {
+						"consentToken": null
+					},
+					"accessToken": null
 				},
 				"device": {
+					"deviceId": null,
 					"supportedInterfaces": {
 						"AudioPlayer": {}
 					}
-				}
+				},
+				"apiEndpoint": "https://api.amazonalexa.com/"
 			},
 			"AudioPlayer": {
 				"offsetInMilliseconds": 0,
@@ -48,7 +58,11 @@ templates = {
 			},
 			"attributes": {},
 			"user": {
-				"userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+				"userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2",
+				"permissions": {
+					"consentToken": null
+				},
+				"accessToken": null
 			}
 		},
 		"context": {
@@ -57,13 +71,19 @@ templates = {
 					"applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
 				},
 				"user": {
-					"userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+					"userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2",
+					"permissions": {
+						"consentToken": null
+					},
+					"accessToken": null
 				},
 				"device": {
+					"deviceId": null,
 					"supportedInterfaces": {
 						"AudioPlayer": {}
 					}
-				}
+				},
+				"apiEndpoint": "https://api.amazonalexa.com/"
 			},
 			"AudioPlayer": {
 				"offsetInMilliseconds": 0,
@@ -91,7 +111,11 @@ templates = {
 			},
 			"attributes": {},
 			"user": {
-				"userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+				"userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2",
+				"permissions": {
+					"consentToken": null
+				},
+				"accessToken": null
 			}
 		},
 		"context": {
@@ -100,13 +124,19 @@ templates = {
 					"applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
 				},
 				"user": {
-					"userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+					"userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2",
+					"permissions": {
+						"consentToken": null
+					},
+					"accessToken": null
 				},
 				"device": {
+					"deviceId": null,
 					"supportedInterfaces": {
 						"AudioPlayer": {}
 					}
-				}
+				},
+				"apiEndpoint": "https://api.amazonalexa.com/"
 			},
 			"AudioPlayer": {
 				"offsetInMilliseconds": 0,

--- a/views/test.ejs
+++ b/views/test.ejs
@@ -21,12 +21,22 @@
         $scope.session = {};
         $scope.intent = null;
         $scope.locale = 'en-US';
+        $scope.accessToken = null;
+        $scope.apiEndpoint = 'https://api.amazonalexa.com/';
+        $scope.consentToken = null;
+        $scope.deviceId = null;
 
         $scope.changetype = function() {
           if ($scope.requestType !== '') {
             $scope.request = clone($scope.templates[$scope.requestType]);
             $scope.request.session.attributes = $scope.session;
-            $scope.request.request.locale = $scope.locale;
+            $scope.request.request.timestamp = new Date();
+
+            $scope.changelocale();
+            $scope.changeAccessToken();
+            $scope.changeConsentToken();
+            $scope.changeDeviceId();
+
           } else {
             $scope.request = {};
           }
@@ -36,6 +46,48 @@
 
         $scope.changelocale = function() {
           $scope.request.request.locale = $scope.locale;
+          $scope.request.context.System.apiEndpoint = $scope.apiEndpoint;
+
+          if ($scope.locale === 'en-US') {
+            $scope.request.context.System.apiEndpoint = 'https://api.amazonalexa.com/';
+          } else {
+            $scope.request.context.System.apiEndpoint = 'https://api.eu.amazonalexa.com';
+          }
+        };
+
+        $scope.changeAccessToken = function() {
+
+          var accessToken = null;
+
+          if ($scope.accessToken) {
+            accessToken = $scope.accessToken;
+          }
+
+          $scope.request.context.System.user.accessToken = accessToken;
+          $scope.request.session.user.accessToken = accessToken;
+        };
+
+        $scope.changeConsentToken = function() {
+
+          var consentToken = null;
+
+          if ($scope.consentToken) {
+            consentToken = $scope.consentToken;
+          }
+
+          $scope.request.context.System.user.permissions.consentToken = consentToken;
+          $scope.request.session.user.permissions.consentToken = consentToken;
+        };
+
+        $scope.changeDeviceId = function() {
+
+          var deviceId = null;
+
+          if ($scope.deviceId) {
+            deviceId = $scope.deviceId;
+          }
+
+          $scope.request.context.System.device.deviceId = deviceId;
         };
 
         $scope.changeintent = function() {
@@ -48,6 +100,7 @@
 
         $scope.post = function() {
           if (Object.keys($scope.request).length !== 0) {
+            $scope.request.request.timestamp = new Date();
             $http.post(location.href, $scope.request)
               .then(function onSuccess(response) {
                 $scope.response = response.data;
@@ -115,6 +168,21 @@
         <option value="intent">IntentRequest</option>
         <option value="session_end">SessionEndedRequest</option>
       </select>
+
+      <div id="deviceId">
+        Device ID:
+        <input id="deviceId_input" type="text" value="" ng-model="deviceId" ng-change="changeDeviceId()" />
+      </div>
+
+      <div id="accessToken">
+        Access Token:
+        <input id="accessToken_input" type="text" value="" ng-model="accessToken" ng-change="changeAccessToken()" />
+      </div>
+
+      <div id="consentToken">
+        Consent Token:
+        <input id="consentToken_input" type="text" value="" ng-model="consentToken" ng-change="changeConsentToken()" />
+      </div>
 
       <div id="intent" ng-show="requestType=='intent'">
         Intent:

--- a/views/test.ejs
+++ b/views/test.ejs
@@ -48,10 +48,10 @@
           $scope.request.request.locale = $scope.locale;
           $scope.request.context.System.apiEndpoint = $scope.apiEndpoint;
 
-          if ($scope.locale === 'en-US') {
-            $scope.request.context.System.apiEndpoint = 'https://api.amazonalexa.com/';
+          if ($scope.locale === 'en-GB' || $scope.locale === 'de-DE') {
+            $scope.request.context.System.apiEndpoint = 'https://api.eu.amazonalexa.com/';
           } else {
-            $scope.request.context.System.apiEndpoint = 'https://api.eu.amazonalexa.com';
+            $scope.request.context.System.apiEndpoint = 'https://api.amazonalexa.com/';
           }
         };
 


### PR DESCRIPTION
Relates to alexa-js/alexa-app#226.

Add support for setting the value of additional request properties in the test page.

  1. ```accessToken``` for skills which support [account linking](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/linking-an-alexa-user-with-a-user-in-your-system).
  1. ```deviceId``` and ```consentToken``` for skills which support the [Device Address API](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/device-address-api).
  1. ```apiEndpoint```, which is set to the values specified in the [documentation](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interface-reference#system-object) based on the current locale. This also supports the [Device Address API](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/device-address-api#base-uris-and-geographic-location-of-the-skill).

The ```timestamp``` property of the request is now also updated to the current date and time when the requests are loaded and posted.