### PR TITLE
Add ja-JP option to test page

### DIFF
--- a/views/test.ejs
+++ b/views/test.ejs
@@ -200,6 +200,7 @@
           <option value="en-US">en-US</option>
           <option value="en-GB">en-GB</option>
           <option value="de-DE">de-DE</option>
+          <option value="ja-JP">ja-JP</option>
         </select>
       </div>
 


### PR DESCRIPTION
Since Amazon announced that they were going to launch Alexa in Japan later this year, adding the `ja-JP` locale to the test page will be very helpful to develop a Japanese Alexa skill.